### PR TITLE
Simplify setup on Linux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        command: [ './install.sh && exec zsh', 'make all && exec zsh' ]
+        command: [ './install.sh && if [[ -n $(zsh -c return) ]]; then exit 1; fi', 'make all && if [[ -n $(zsh -c return) ]]; then exit 1; fi' ]
 
       fail-fast: true
 
@@ -27,7 +27,7 @@ jobs:
         run: docker build . -t dotfiles
 
       - name: Run Dockerfile
-        run: docker run dotfiles ${{ matrix.command }}
+        run: docker run dotfiles "${{ matrix.command }}"
 
   build:
     name: Install locally
@@ -50,5 +50,5 @@ jobs:
       run: ${{ matrix.command }}
 
     - name: Ensure zsh works
-      run: exec zsh
+      run: if [[ -n $(zsh -c return) ]]; then exit 1; fi
       if: ${{ matrix.command == 'make all' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        command: [ './install.sh && if [[ -n $(zsh -c return) ]]; then exit 1; fi', 'make all && if [[ -n $(zsh -c return) ]]; then exit 1; fi' ]
+        command: [ './install.sh && ([[ -z $(zsh -c return) ]] || exit 1)', 'make all && ([[ -z $(zsh -c return) ]] || exit 1)' ]
 
       fail-fast: true
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,14 +13,6 @@ jobs:
     name: Install in Docker
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        command:
-          - ./install.sh && if [[ -n $(zsh -c return) ]]; then exit 1; fi
-          - make all && if [[ -n $(zsh -c return) ]]; then exit 1; fia
-
-      fail-fast: true
-
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2
@@ -29,7 +21,7 @@ jobs:
         run: docker build . -t dotfiles
 
       - name: Run Dockerfile
-        run: docker run dotfiles ${{ matrix.command }}
+        run: docker run dotfiles
 
   build:
     name: Install locally

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,9 @@ jobs:
 
     strategy:
       matrix:
-        command: [ './install.sh && ([[ -z $(zsh -c return) ]] || exit 1)', 'make all && ([[ -z $(zsh -c return) ]] || exit 1)' ]
+        command:
+          - ./install.sh && if [[ -n $(zsh -c return) ]]; then exit 1; fi
+          - make all && if [[ -n $(zsh -c return) ]]; then exit 1; fia
 
       fail-fast: true
 
@@ -27,7 +29,7 @@ jobs:
         run: docker build . -t dotfiles
 
       - name: Run Dockerfile
-        run: docker run dotfiles "${{ matrix.command }}"
+        run: docker run dotfiles ${{ matrix.command }}
 
   build:
     name: Install locally

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,6 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, macos-latest ]
-        command: [ './install.sh', 'make all' ]
 
     runs-on: ${{ matrix.os }}
 
@@ -49,8 +48,9 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Run install command
-      run: ${{ matrix.command }}
+      run: ./install.sh
+
+    - run: exec zsh
 
     - name: Ensure zsh works
       run: if [[ -n $(zsh -c return) ]]; then exit 1; fi
-      if: ${{ matrix.command == 'make all' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,25 +8,16 @@ on:
   schedule:
     - cron: '0 3 * * 6'
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  build-linux:
-    name: Install on Linux locally
+  build-docker:
+    name: Install in Docker
     runs-on: ubuntu-latest
 
-    steps:
-    - name: Checkout repo
-      uses: actions/checkout@v2
+    strategy:
+      matrix:
+        command: [ './install.sh && exec zsh', 'make all && exec zsh' ]
 
-    - name: Run install script
-      run: ./install.sh
-
-    - name: Ensure zsh works
-      run: exec zsh
-
-  build-linux-docker:
-    name: Install on Linux in Docker
-    runs-on: ubuntu-latest
+      fail-fast: true
 
     steps:
       - name: Checkout repo
@@ -36,21 +27,28 @@ jobs:
         run: docker build . -t dotfiles
 
       - name: Run Dockerfile
-        run: docker run dotfiles
+        run: docker run dotfiles ${{ matrix.command }}
 
-  build-macos:
-    name: Install on macOS
-    runs-on: macos-latest
+  build:
+    name: Install locally
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, macos-latest ]
+        command: [ './install.sh', 'make all' ]
+
+    runs-on: ${{ matrix.os }}
 
     steps:
     - name: Unlink preinstalled node
       run: brew unlink node@12
+      if: ${{ startsWith(matrix.os, 'macos') }}
 
     - name: Checkout repo
       uses: actions/checkout@v2
 
-    - name: Run install script
-      run: ./install.sh
+    - name: Run install command
+      run: ${{ matrix.command }}
 
     - name: Ensure zsh works
       run: exec zsh
+      if: ${{ matrix.command == 'make all' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,9 @@ jobs:
     - name: Run install command
       run: ./install.sh
 
-    - run: exec zsh
+    - run: pwd
+    - run: ls
+    - run: HOME=$GITHUB_WORKSPACE exec zsh
 
     - name: Ensure zsh works
       run: if [[ -n $(zsh -c return) ]]; then exit 1; fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,9 +42,5 @@ jobs:
     - name: Run install command
       run: ./install.sh
 
-    - run: pwd
-    - run: ls
-    - run: HOME=$GITHUB_WORKSPACE exec zsh
-
     - name: Ensure zsh works
-      run: if [[ -n $(zsh -c return) ]]; then exit 1; fi
+      run: if [[ -n $(HOME=$GITHUB_WORKSPACE zsh -c return) ]]; then exit 1; fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,4 @@ ADD . .
 
 ENV CI=1
 
-CMD bash -c './install.sh && ([[ -z $(zsh -c return) ]] || exit 1)'
+CMD bash -c './install.sh && if [[ -n $(zsh -c return) ]]; then exit 1; fi'

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:latest
 
 LABEL Name=dotfiles
 
-RUN apt-get -y update && apt-get install -y curl make sudo
+RUN apt-get -y update && apt-get install -y --no-install-recommends make sudo
 
 # Add user
 RUN addgroup --gid 1000 user \
@@ -16,4 +16,4 @@ ADD . .
 
 ENV CI=1
 
-CMD ./install.sh && exec zsh
+CMD ./install.sh && if [[ -n $(zsh -c return) ]]; then exit 1; fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,4 @@ ADD . .
 
 ENV CI=1
 
-CMD ./install.sh && if [[ -n $(zsh -c return) ]]; then exit 1; fi
+CMD bash -c './install.sh && ([[ -z $(zsh -c return) ]] || exit 1)'

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:latest
 
 LABEL Name=dotfiles
 
-RUN apt-get -y update && apt-get install -y make sudo
+RUN apt-get -y update && apt-get install -y curl make sudo
 
 # Add user
 RUN addgroup --gid 1000 user \
@@ -16,4 +16,4 @@ ADD . .
 
 ENV CI=1
 
-CMD ./install.sh && zsh
+CMD ./install.sh && exec zsh

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ stow-macos: brew
 	is-executable stow || brew install stow
 
 stow-linux: core-linux
-	is-executable stow || sudo apt-get -y install stow
+	is-executable stow || sudo apt-get -y --no-install-recommends install stow
 
 sudo:
 ifndef CI
@@ -50,7 +50,7 @@ unlink: stow-$(OS)
 	for FILE in $$(\ls -A runcom); do if [ -f $(HOME)/$$FILE.bak ]; then mv -v $(HOME)/$$FILE.bak $(HOME)/$${FILE%%.bak}; fi; done
 
 brew:
-	is-executable brew || /bin/bash -c "$$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
+	is-executable brew || curl -V >/dev/null && /bin/bash -c "$$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
 
 zsh-macos: ZSH_BIN=/usr/local/bin/zsh
 zsh-macos: SHELLS=/private/etc/shells
@@ -58,7 +58,7 @@ zsh-macos: brew
 	if ! grep -q $(ZSH_BIN) $(SHELLS); then brew install zsh && sudo append $(ZSH_BIN) $(SHELLS); fi
 
 zsh-linux:
-	is-executable zsh || sudo apt-get install -y zsh
+	is-executable zsh || sudo apt-get install -y --no-install-recommends zsh
 
 change-shell: zsh-$(OS)
 ifndef CI

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ export STOW_DIR := $(DOTFILES_DIR)
 
 .PHONY: test
 
-dotfiles: link
+#dotfiles: link
 
 all: $(OS)
 

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,8 @@ export STOW_DIR := $(DOTFILES_DIR)
 
 .PHONY: test
 
+dotfiles: link
+
 all: $(OS)
 
 macos: sudo brew change-shell node ruby packages-macos link mackup

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ unlink: stow-$(OS)
 	for FILE in $$(\ls -A runcom); do if [ -f $(HOME)/$$FILE.bak ]; then mv -v $(HOME)/$$FILE.bak $(HOME)/$${FILE%%.bak}; fi; done
 
 brew:
-	is-executable brew || curl -V >/dev/null && /bin/bash -c "$$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
+	is-executable brew || curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh | bash
 
 zsh-macos: ZSH_BIN=/usr/local/bin/zsh
 zsh-macos: SHELLS=/private/etc/shells
@@ -65,10 +65,10 @@ endif
 
 ohmyzsh: OH_MY_ZSH_HOME="$(XDG_CONFIG_HOME)/oh-my-zsh"
 ohmyzsh:
-	[[ -d $(OH_MY_ZSH_HOME) ]] || curl -V >/dev/null && curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh | ZSH=$(OH_MY_ZSH_HOME) sh
+	[[ -d $(OH_MY_ZSH_HOME) ]] || curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh | ZSH=$(OH_MY_ZSH_HOME) sh
 
 nodenv: brew
-	is-executable nodenv || export PATH=$(HOME)/.nodenv/shims:$(PATH); curl -V >/dev/null && curl -fsSL https://raw.githubusercontent.com/nodenv/nodenv-installer/master/bin/nodenv-installer | bash
+	is-executable nodenv || export PATH=$(HOME)/.nodenv/shims:$(PATH); curl -fsSL https://raw.githubusercontent.com/nodenv/nodenv-installer/master/bin/nodenv-installer | bash
 
 node: nodenv
 

--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,6 @@ export STOW_DIR := $(DOTFILES_DIR)
 
 .PHONY: test
 
-#dotfiles: link
-
 all: $(OS)
 
 macos: sudo brew change-shell node ruby packages-macos link mackup

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,10 @@ linux: sudo core-linux brew change-shell packages-linux link
 
 core-linux:
 	sudo apt-get update
-	sudo apt-get install -y build-essential curl git locales
+	is-executable curl || sudo apt-get install -y curl
+	is-executable gcc || sudo apt-get install -y build-essential
+	is-executable git || sudo apt-get install -y git
+	is-executable locales || sudo apt-get install -y locales
 	sudo sh -c "echo 'en_US.UTF-8 UTF-8' >> /etc/locale.gen"
 	sudo locale-gen
 
@@ -34,7 +37,7 @@ endif
 packages-macos: ohmyzsh brew-packages node-packages gems python-packages
 
 packages-linux: ohmyzsh
-	/home/linuxbrew/.linuxbrew/bin/brew install starship thefuck tmux
+	/home/linuxbrew/.linuxbrew/bin/brew install starship
 
 link: stow-$(OS)
 	for FILE in $$(\ls -A runcom); do if [ -f $(HOME)/$$FILE -a ! -h $(HOME)/$$FILE ]; then mv -v $(HOME)/$$FILE{,.bak}; fi; done

--- a/Makefile
+++ b/Makefile
@@ -67,10 +67,10 @@ endif
 
 ohmyzsh: OH_MY_ZSH_HOME="$(XDG_CONFIG_HOME)/oh-my-zsh"
 ohmyzsh:
-	[[ -d $(OH_MY_ZSH_HOME) ]] || curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh | ZSH=$(OH_MY_ZSH_HOME) sh
+	[[ -d $(OH_MY_ZSH_HOME) ]] || curl -V >/dev/null && curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh | ZSH=$(OH_MY_ZSH_HOME) sh
 
 nodenv: brew
-	is-executable nodenv || export PATH=$(HOME)/.nodenv/shims:$(PATH); curl -fsSL https://raw.githubusercontent.com/nodenv/nodenv-installer/master/bin/nodenv-installer | bash
+	is-executable nodenv || export PATH=$(HOME)/.nodenv/shims:$(PATH); curl -V >/dev/null && curl -fsSL https://raw.githubusercontent.com/nodenv/nodenv-installer/master/bin/nodenv-installer | bash
 
 node: nodenv
 

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ all: $(OS)
 
 macos: sudo brew change-shell node ruby packages-macos link mackup
 
-linux: sudo core-linux brew change-shell packages-linux link
+linux: sudo core-linux change-shell packages-linux link
 
 core-linux:
 	sudo apt-get update
@@ -37,7 +37,7 @@ endif
 packages-macos: ohmyzsh brew-packages node-packages gems python-packages
 
 packages-linux: ohmyzsh
-	/home/linuxbrew/.linuxbrew/bin/brew install starship
+	export FORCE=1; curl -fsSL https://starship.rs/install.sh | bash
 
 link: stow-$(OS)
 	for FILE in $$(\ls -A runcom); do if [ -f $(HOME)/$$FILE -a ! -h $(HOME)/$$FILE ]; then mv -v $(HOME)/$$FILE{,.bak}; fi; done
@@ -68,7 +68,7 @@ endif
 
 ohmyzsh: OH_MY_ZSH_HOME="$(XDG_CONFIG_HOME)/oh-my-zsh"
 ohmyzsh:
-	[[ -d $(OH_MY_ZSH_HOME) ]] || curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh | ZSH=$(OH_MY_ZSH_HOME) sh
+	test -d $(OH_MY_ZSH_HOME) || curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh | ZSH=$(OH_MY_ZSH_HOME) sh
 
 nodenv: brew
 	is-executable nodenv || export PATH=$(HOME)/.nodenv/shims:$(PATH); curl -fsSL https://raw.githubusercontent.com/nodenv/nodenv-installer/master/bin/nodenv-installer | bash

--- a/README.md
+++ b/README.md
@@ -36,13 +36,11 @@ This will clone (using `git`), or download (using `curl` or `wget`), this repo t
 git clone https://github.com/lumaxis/dotfiles.git ~/dotfiles
 ```
 
-Use the [Makefile](./Makefile) to symlink [runcom](./runcom) and [config](./config) (using [stow](https://www.gnu.org/software/stow/)) by default or also install everything [listed above](#package-overview):
+- Use the [Makefile](./Makefile) to install everything [listed above](#package-overview), and symlink [runcom](./runcom) and [config](./config) (using [stow](https://www.gnu.org/software/stow/)):
 
 ```shell-script
 cd ~/dotfiles
-make # Does the minimal setup and installs symlinks
-
-make all # Sets up dotfiles and installs default packages
+make
 ```
 
 ## Post-install

--- a/README.md
+++ b/README.md
@@ -18,22 +18,32 @@ It targets macOS systems, but it should work on \*nix as well (with `apt-get`).
 
 On a sparkling fresh installation of macOS:
 
-    sudo softwareupdate -i -a
-    xcode-select --install
+```shell-script
+sudo softwareupdate -i -a
+xcode-select --install
+```
 
 The Xcode Command Line Tools includes `git` and `make` (not available on stock macOS).
 Then, install this repo with `curl` available:
 
-    bash -c "`curl -fsSL https://raw.githubusercontent.com/lumaxis/dotfiles/master/remote-install.sh`"
+```shell-script
+bash -c "`curl -fsSL https://raw.githubusercontent.com/lumaxis/dotfiles/master/remote-install.sh`"
+```
 
 This will clone (using `git`), or download (using `curl` or `wget`), this repo to `~/dotfiles`. Alternatively, clone manually into the desired location:
 
-    git clone https://github.com/lumaxis/dotfiles.git ~/dotfiles
+```shell-script
+git clone https://github.com/lumaxis/dotfiles.git ~/dotfiles
+```
 
-Use the [Makefile](./Makefile) to install everything [listed above](#package-overview), and symlink [runcom](./runcom) and [config](./config) (using [stow](https://www.gnu.org/software/stow/)):
+Use the [Makefile](./Makefile) to symlink [runcom](./runcom) and [config](./config) (using [stow](https://www.gnu.org/software/stow/)) by default or also install everything [listed above](#package-overview):
 
-    cd ~/dotfiles
-    make
+```shell-script
+cd ~/dotfiles
+make # Does the minimal setup and installs symlinks
+
+make all # Sets up dotfiles and installs default packages
+```
 
 ## Post-install
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ This will clone (using `git`), or download (using `curl` or `wget`), this repo t
 git clone https://github.com/lumaxis/dotfiles.git ~/dotfiles
 ```
 
-- Use the [Makefile](./Makefile) to install everything [listed above](#package-overview), and symlink [runcom](./runcom) and [config](./config) (using [stow](https://www.gnu.org/software/stow/)):
+Use the [Makefile](./Makefile) to install everything [listed above](#package-overview), and symlink [runcom](./runcom) and [config](./config) (using [stow](https://www.gnu.org/software/stow/)):
 
 ```shell-script
 cd ~/dotfiles

--- a/system/.oh-my-zsh
+++ b/system/.oh-my-zsh
@@ -59,6 +59,8 @@ VSCODE=code-insiders
 # Which plugins would you like to load? (plugins can be found in ~/.oh-my-zsh/plugins/*)
 # Custom plugins may be added to ~/.oh-my-zsh/custom/plugins/
 # Example format: plugins=(rails git textmate ruby lighthouse)
-plugins=(dash docker git gitignore kubectl npm npx osx rbenv thefuck tmux vscode)
+plugins=(dash docker git gitignore kubectl npm npx osx rbenv tmux vscode)
+is-executable fuck || plugins+=(thefuck)
+is-executable tmux || plugins+=(tmux)
 
 source $ZSH/oh-my-zsh.sh


### PR DESCRIPTION
- Simplifies GitHub Actions CI setup
- Check more selectively which packages need to be installed
- Skip installing Homebrew on Linux since it's just so slow (and not non-interactive by default).